### PR TITLE
Actually Add real Queries to db.cql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/chat/node_modules

--- a/chat/db.cql
+++ b/chat/db.cql
@@ -1,14 +1,22 @@
 DROP KEYSPACE IF EXISTS market_chat;
-CREATE KEYSPACE market_chat;
 
-CREATE TABLE messages(
+CREATE KEYSPACE market_chat WITH replication = {
+  'class': 'SimpleStrategy',
+  'replication_factor': 1
+};
 
+CREATE TABLE market_chat.chats (
+  chat_id uuid PRIMARY KEY,
+  name text,
+  participants set<uuid>,
+  created_at timestamp
 );
 
-
--- Message:
--- Time (cassandra time)
--- Content (THE MESSAGE)
--- FromUser (uuid from supabase)
--- ToUser (uuid from supabase)
--- Read (bool)
+CREATE TABLE market_chat.messages (
+  chat_id uuid,
+  message_time timeuuid,
+  from_user uuid,
+  content text,
+  read boolean,
+  PRIMARY KEY (chat_id, message_time)
+) WITH CLUSTERING ORDER BY (message_time ASC);


### PR DESCRIPTION
Added db cql queries to build cassandra tables

I think this structure is good: 

CREATE TABLE market_chat.chats (
  chat_id uuid PRIMARY KEY,
  name text,
  participants set<uuid>,
  created_at timestamp
);

CREATE TABLE market_chat.messages (
  chat_id uuid,
  message_time timeuuid,
  from_user uuid,
  content text,
  read boolean,
  PRIMARY KEY (chat_id, message_time)
) WITH CLUSTERING ORDER BY (message_time ASC);
